### PR TITLE
Add ability to ignore public members of a subclass of MarshalByRefObject

### DIFF
--- a/src/Mapper.cs
+++ b/src/Mapper.cs
@@ -119,7 +119,7 @@ namespace DBus
 				return true;
 
 			if (type.IsSubclassOf (typeof (MarshalByRefObject)) &&
-			    type.GetCustomAttributes (typeof (IgnoreMarshalByRefObjectBaseClassAttribute), true).Length == 0)
+			    type.GetCustomAttributes (typeof (ExportInterfaceMembersOnlyAttribute), true).Length == 0)
 				return true;
 
 			return false;
@@ -362,7 +362,7 @@ namespace DBus
 	}
 
 	[AttributeUsage (AttributeTargets.Class, AllowMultiple=false, Inherited=true)]
-	public class IgnoreMarshalByRefObjectBaseClassAttribute : Attribute
+	public class ExportInterfaceMembersOnlyAttribute : Attribute
 	{
 	}
 


### PR DESCRIPTION
For Banshee on Windows, I've done some major work to make "single instance" and "remote control" work by using .NET remoting for the non-dbus case. In order to do that, the remote types used for both dbus and .NET remoting need to subclass from MarshalByRefObject. Currently that causes a problem because dbus-sharp tries to expose any public API on those types now (instead of only the API exposed by the explicit interfaces).

This change just adds one new attribute that can decorate classes and tell dbus-sharp to not expose the classes public API, only the API exposed through the defined interfaces.
