### PR TITLE
Unixerror marshalling

### DIFF
--- a/src/Unix.cs
+++ b/src/Unix.cs
@@ -5,6 +5,7 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
+using Mono.Unix.Native;
 
 namespace DBus.Unix
 {
@@ -128,36 +129,17 @@ namespace DBus.Unix
 
 	static class UnixError
 	{
-		internal const string LIBC = "libc";
-
-		[DllImport (LIBC, CallingConvention=CallingConvention.Cdecl, SetLastError=false)]
-		static extern IntPtr strerror (int errnum);
-
-		static string GetErrorString (int errnum)
-		{
-			IntPtr strPtr = strerror (errnum);
-
-			if (strPtr == IntPtr.Zero)
-				return "Unknown Unix error";
-
-			return Marshal.PtrToStringAnsi (strPtr);
-		}
-
-		// FIXME: Don't hard-code this.
-		const int EINTR = 4;
-
 		public static bool ShouldRetry
 		{
 			get {
-				int errno = System.Runtime.InteropServices.Marshal.GetLastWin32Error ();
-				return errno == EINTR;
+				return Mono.Unix.Native.Syscall.GetLastError () == Errno.EINTR;
 			}
 		}
 
 		public static Exception GetLastUnixException ()
 		{
-			int errno = System.Runtime.InteropServices.Marshal.GetLastWin32Error ();
-			return new Exception (String.Format ("Error {0}: {1}", errno, GetErrorString (errno)));
+			Errno errno = Mono.Unix.Native.Syscall.GetLastError ();
+			return new Exception (String.Format ("Error {0}: {1}", errno, Mono.Unix.Native.Syscall.strerror (errno)));
 		}
 	}
 


### PR DESCRIPTION
Make UnixError just call the already bound implementation in Mono.Posix.
