### PR TITLE
Unix uid

### DIFF
--- a/src/Unix.cs
+++ b/src/Unix.cs
@@ -103,29 +103,6 @@ namespace DBus.Unix
 		}
 	}
 
-	static class UnixUid
-	{
-		internal const string LIBC = "libc";
-
-		[DllImport (LIBC, CallingConvention=CallingConvention.Cdecl, SetLastError=false)]
-		static extern uint getuid ();
-
-		[DllImport (LIBC, CallingConvention=CallingConvention.Cdecl, SetLastError=false)]
-		static extern uint geteuid ();
-
-		public static long GetUID ()
-		{
-			long uid = getuid ();
-			return uid;
-		}
-
-		public static long GetEUID ()
-		{
-			long euid = geteuid ();
-			return euid;
-		}
-	}
-
 	static class UnixError
 	{
 		internal const string LIBC = "libc";

--- a/src/UnixNativeTransport.cs
+++ b/src/UnixNativeTransport.cs
@@ -21,7 +21,7 @@ namespace DBus.Transports
 
 		public override string AuthString ()
 		{
-			long uid = UnixUid.GetEUID ();
+			long uid = Mono.Unix.Native.Syscall.geteuid ();
 			return uid.ToString ();
 		}
 

--- a/src/dbus-sharp.csproj
+++ b/src/dbus-sharp.csproj
@@ -36,6 +36,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml" />
+    <Reference Include="Mono.Posix" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Address.cs" />


### PR DESCRIPTION
The only call we need from UnixUid is get effective uid which is bound in Mono.Posix, so use it.
