### PR TITLE
Added initial check for libsocket

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -48,6 +48,8 @@ for asm in $required_assemblies; do
 	fi
 done
 
+AC_CHECK_LIB([socket], [main],, AC_MSG_ERROR(missing required library libsocket))
+
 AC_OUTPUT([
 Makefile
 dbus-sharp-1.0.pc


### PR DESCRIPTION
It seems as the dbus-sharp does use happycoders libsocket but it does not fail configure if non-existant on system. As such I got "Unhandled Exception: System.Exception: Unable to open the session message bus. ---> System.DllNotFoundException: libsocket" when trying the recent version without libsocket installed (compiled and such fine)

This pull request adds a simple check for the existance of libsocket to the configure.ac.

Tangential of the pull request and something I'd like to discuss how it could be fixed is that on Ubuntu I had to both install libsocket _and_ symlink it to /usr/lib/libsocket.so as it never created the libsocket.so but only libsocket.so.0 and libsocket.so.1.6. It looks like libsocket doesn't have a pkg config file so I guess the latter problem is unavoidable and that ubuntu should create a libsocket.so. I'd love some thoughts on this and if you agree I'll start an issue with the ubuntu packagers about that latter problem.
