### PR TITLE
Fix for libc dllmap

### DIFF
--- a/src/Unix.cs
+++ b/src/Unix.cs
@@ -197,7 +197,7 @@ namespace DBus.Unix
 
 		// Solaris provides socket functionality in libsocket rather than libc.
 		// We use a dllmap in the .config to deal with this.
-		internal const string LIBSOCKET = "libsocket";
+		internal const string LIBSOCKET = "libc";
 
 		public const short AF_UNIX = 1;
 		// FIXME: SOCK_STREAM is 2 on Solaris

--- a/src/dbus-sharp.dll.config
+++ b/src/dbus-sharp.dll.config
@@ -1,3 +1,13 @@
 <configuration>
-  <dllmap dll="libsocket" os="!solaris" target="libc"/>
+  <dllmap dll="libc">
+    <dllentry os="solaris" dll="libsocket.so.1" name="socket" target="socket"/>
+    <dllentry os="solaris" dll="libsocket.so.1" name="connect" target="connect"/>
+    <dllentry os="solaris" dll="libsocket.so.1" name="bind" target="bind"/>
+    <dllentry os="solaris" dll="libsocket.so.1" name="listen" target="listen"/>
+    <dllentry os="solaris" dll="libsocket.so.1" name="accept" target="accept"/>
+    <dllentry os="solaris" dll="libsocket.so.1" name="getsockopt" target="getsockopt"/>
+    <dllentry os="solaris" dll="libsocket.so.1" name="setsockopt" target="setsockopt"/>
+    <dllentry os="solaris" dll="libsocket.so.1" name="recvmsg" target="recvmsg"/>
+    <dllentry os="solaris" dll="libsocket.so.1" name="sendmsg" target="sendmsg"/>
+  </dllmap>
 </configuration>


### PR DESCRIPTION
Reverse the way the dllmap for libsocket is handled, by using libc (mapped by /etc/mono/config) the default, and remapping this to libsocket.so.1 on Solaris. This neatly avoids the dllmap-using-dllmap problem introduced in c66aebc7ff1c257140662380c9a51cddd45b825f.
