### PR TITLE
Connection.GetObject: do not check that the bus name exists

### DIFF
--- a/src/Connection.cs
+++ b/src/Connection.cs
@@ -399,9 +399,6 @@ namespace DBus
 
 		public object GetObject (Type type, string bus_name, ObjectPath path)
 		{
-			if (!CheckBusNameExists (bus_name))
-				return null;
-
 			//if the requested type is an interface, we can implement it efficiently
 			//otherwise we fall back to using a transparent proxy
 			if (type.IsInterface || type.IsAbstract) {


### PR DESCRIPTION
This check did not exist in 0.7, but was added in e0eed784d7 before 0.8.

When D-Bus service activation is used, the desired bus name is not
going to exist at this point; when we call a method, the dbus-daemon
transparently starts the service before delivering the message.
This is particularly important for services that are not normally
running before they are needed, such as polkit and systemd-hostnamed.
Calling NameHasOwner also doubles the number of method calls if you're
only making one method call on the object, and has a race condition:
if the service exits between the successful NameHasOwner call and the
next method call, the caller will still have to deal with that.

Working around the check by doing a StartServiceByName first is
inefficient, and also introduces a race condition: if the service
exits between StartServiceByName success and NameHasOwner, then
GetObject would still return null.
