### PR TITLE
proxy: Enable DBus property extraction via CLR properties

### DIFF
--- a/dbus-sharp.sln
+++ b/dbus-sharp.sln
@@ -29,7 +29,18 @@ Global
 		{736160C3-844E-43D9-8106-E492D74D92CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
-		StartupItem = src\dbus-sharp.csproj
+		Policies = $0
+		$0.TextStylePolicy = $1
+		$1.FileWidth = 120
+		$1.TabsToSpaces = False
+		$1.inheritsSet = VisualStudio
+		$1.inheritsScope = text/plain
+		$1.scope = text/x-csharp
+		$0.CSharpFormattingPolicy = $2
+		$2.AfterDelegateDeclarationParameterComma = True
+		$2.inheritsSet = Mono
+		$2.inheritsScope = text/x-csharp
+		$2.scope = text/x-csharp
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/BusObject.cs
+++ b/src/BusObject.cs
@@ -3,6 +3,7 @@
 // See COPYING for details
 
 using System;
+using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
 using System.Collections.Generic;
@@ -171,7 +172,7 @@ namespace DBus
 
 			MessageReader reader = SendMethodCall ("org.freedesktop.DBus.Properties", "Get", "ss", writer, typeof(object), out exception);
 
-			return reader.ReadVariant ();
+			return reader.ReadValues ().FirstOrDefault ();
 		}
 
 		public void SendPropertySet (string iface, string property, object value)

--- a/src/BusObject.cs
+++ b/src/BusObject.cs
@@ -162,6 +162,29 @@ namespace DBus
 			return retVal;
 		}
 
+		public object SendPropertyGet (string iface, string property)
+		{
+			Exception exception;
+			MessageWriter writer = new MessageWriter ();
+			writer.Write (iface);
+			writer.Write (property);
+
+			MessageReader reader = SendMethodCall ("org.freedesktop.DBus.Properties", "Get", "ss", writer, typeof(object), out exception);
+
+			return reader.ReadVariant ();
+		}
+
+		public void SendPropertySet (string iface, string property, object value)
+		{
+			Exception exception;
+			MessageWriter writer = new MessageWriter ();
+			writer.Write (iface);
+			writer.Write (property);
+			writer.Write (typeof(object), value);
+
+			SendMethodCall ("org.freedesktop.DBus.Properties", "Set", "ssv", writer, typeof(void), out exception);
+		}
+
 		public void Invoke (MethodBase methodBase, string methodName, object[] inArgs, out object[] outArgs, out object retVal, out Exception exception)
 		{
 			outArgs = new object[0];

--- a/src/ExportObject.cs
+++ b/src/ExportObject.cs
@@ -14,15 +14,26 @@ namespace DBus
 {
 	using Protocol;
 
+	internal class PropertyCallers {
+		public Type Type { get; set; }
+		public MethodCaller Get { get; set; }
+		public MethodCaller Set { get; set; }
+	}
+
 	//TODO: perhaps ExportObject should not derive from BusObject
 	internal class ExportObject : BusObject, IDisposable
 	{
 		//maybe add checks to make sure this is not called more than once
 		//it's a bit silly as a property
 		bool isRegistered = false;
+
+		Dictionary<string, PropertyInfo> propertyInfoCache = new Dictionary<string, PropertyInfo> ();
+
 		Dictionary<string, MethodInfo> methodInfoCache = new Dictionary<string, MethodInfo> ();
 
 		static readonly Dictionary<MethodInfo, MethodCaller> mCallers = new Dictionary<MethodInfo, MethodCaller> ();
+
+		static readonly Dictionary<PropertyInfo, PropertyCallers> pCallers = new Dictionary<PropertyInfo, PropertyCallers> ();
 
 		public ExportObject (Connection conn, ObjectPath object_path, object obj) : base (conn, null, object_path)
 		{
@@ -79,11 +90,25 @@ namespace DBus
 			return new ExportObject (conn, object_path, obj);
 		}
 
+		private static string Key (string iface, string member)
+		{
+			return string.Format ("{0}.{1}", iface, member);
+		}
+
 		public virtual void HandleMethodCall (MessageContainer method_call)
 		{
+			switch (method_call.Interface) {
+			case "org.freedesktop.DBus.Properties":
+				HandlePropertyCall (method_call);
+				return;
+			}
+
+			var cache_key = Key (method_call.Interface, method_call.Member);
 			MethodInfo mi;
-			if (!methodInfoCache.TryGetValue (method_call.Member, out mi))
-				methodInfoCache[method_call.Member] = mi = Mapper.GetMethod (Object.GetType (), method_call);
+			if (!methodInfoCache.TryGetValue (cache_key, out mi)) {
+				mi = Mapper.GetMethod (Object.GetType (), method_call);
+				methodInfoCache [cache_key] = mi;
+			}
 
 			if (mi == null) {
 				conn.MaybeSendUnknownMethodError (method_call);
@@ -110,6 +135,13 @@ namespace DBus
 				raisedException = e;
 			}
 
+			IssueReply (method_call, outSig, retWriter, mi, raisedException);
+		}
+
+		private void IssueReply (MessageContainer method_call, Signature outSig, MessageWriter retWriter, MethodInfo mi, Exception raisedException)
+		{
+			Message msg = method_call.Message;
+
 			if (!msg.ReplyExpected)
 				return;
 
@@ -118,6 +150,7 @@ namespace DBus
 			if (raisedException == null) {
 				MessageContainer method_return = new MessageContainer {
 					Type = MessageType.MethodReturn,
+					Destination = method_call.Sender,
 					ReplySerial = msg.Header.Serial
 				};
 				replyMsg = method_return.Message;
@@ -138,10 +171,79 @@ namespace DBus
 					replyMsg = method_call.CreateError (Mapper.GetInterfaceName (raisedException.GetType ()), raisedException.Message);
 			}
 
-			if (method_call.Sender != null)
-				replyMsg.Header[FieldCode.Destination] = method_call.Sender;
-
 			conn.Send (replyMsg);
+		}
+
+		private void HandlePropertyCall (MessageContainer method_call)
+		{
+			Message msg = method_call.Message;
+			MessageReader msgReader = new MessageReader (msg);
+			MessageWriter retWriter = new MessageWriter ();
+
+			object[] args = MessageHelper.GetDynamicValues (msg);
+
+			string face = (string) args [0];
+			string name = (string) args [1];
+
+			PropertyInfo p = GetPropertyInfo (Object.GetType (), face, name);
+			PropertyCallers pcs = GetPropertyCallers (p);
+
+			MethodCaller pc;
+			MethodInfo mi;
+
+			switch (method_call.Member) {
+			case "Set":
+				pc = pcs.Set;
+				mi = p.GetSetMethod ();
+				break;
+			case "Get":
+				pc = pcs.Get;
+				mi = p.GetGetMethod ();
+				break;
+			case "GetAll":
+				throw new NotImplementedException ();
+			default:
+				throw new ArgumentException (string.Format ("No such method {0}.{1}", method_call.Interface, method_call.Member));
+			}
+
+			if (null == pc || null == mi) {
+				throw new MissingMethodException ();
+			}
+
+			Exception raised = null;
+			try {
+				pc (Object, msgReader, msg, retWriter);
+			} catch (Exception e) {
+				raised = e;
+			}
+
+			Signature inSig, outSig;
+			TypeImplementer.SigsForMethod (mi, out inSig, out outSig);
+
+			IssueReply (method_call, outSig, retWriter, mi, raised);
+		}
+
+		private PropertyInfo GetPropertyInfo (Type type, string @interface, string property)
+		{
+			var key = Key (@interface, property);
+			PropertyInfo pi;
+			if (!propertyInfoCache.TryGetValue (key, out pi)) {
+				pi = Mapper.GetPublicProperties(Mapper.GetInterfaceType (type, @interface)).First (x => property == x.Name);
+				propertyInfoCache [key] = pi;
+			}
+
+			return  pi;
+		}
+
+		private static PropertyCallers GetPropertyCallers (PropertyInfo pi)
+		{
+			PropertyCallers pCaller;
+			if (!pCallers.TryGetValue (pi, out pCaller)) {
+				pCaller = TypeImplementer.GenPropertyCallers (pi);
+				pCallers[pi] = pCaller;
+			}
+
+			return pCaller;
 		}
 
 		public object Object {

--- a/src/Mapper.cs
+++ b/src/Mapper.cs
@@ -35,6 +35,16 @@ namespace DBus
 			return argName;
 		}
 
+		public static Type GetInterfaceType(Type type, string iface)
+		{
+			return type.GetInterfaces ().FirstOrDefault (x => iface == GetInterfaceName (x));
+		}
+
+		public static IEnumerable<PropertyInfo> GetPublicProperties (Type type)
+		{
+			return type.GetProperties (BindingFlags.Instance | BindingFlags.Public | BindingFlags.DeclaredOnly);
+		}
+
 		public static IEnumerable<KeyValuePair<Type, MemberInfo>> GetPublicMembers (Type type)
 		{
 			//note that Type.GetInterfaces() returns all interfaces with flattened hierarchy
@@ -74,6 +84,7 @@ namespace DBus
 		public static MethodInfo GetMethod (Type type, MessageContainer method_call)
 		{
 			var mems = Mapper.GetPublicMembers (type).ToArray ();
+
 			foreach (var memberForType in mems) {
 				//this could be made more efficient by using the given interface name earlier and avoiding walking through all public interfaces
 				if (method_call.Interface != null)

--- a/src/Mapper.cs
+++ b/src/Mapper.cs
@@ -37,7 +37,22 @@ namespace DBus
 
 		public static Type GetInterfaceType(Type type, string iface)
 		{
-			return type.GetInterfaces ().FirstOrDefault (x => iface == GetInterfaceName (x));
+			return type.GetInterfaces()
+				.Concat(GetHierarchy(type))
+				.FirstOrDefault (x => iface == GetInterfaceName (x));
+		}
+
+		private static IEnumerable<Type> GetHierarchy(Type type)
+		{
+			if (IsPublic (type)) {
+				yield return type;
+			}
+
+			foreach (var super in GetHierarchy (type.BaseType)) {
+				if (IsPublic (type)) {
+					yield return super;
+				}
+			}
 		}
 
 		public static IEnumerable<PropertyInfo> GetPublicProperties (Type type)

--- a/src/Protocol/MessageReader.cs
+++ b/src/Protocol/MessageReader.cs
@@ -72,6 +72,13 @@ namespace DBus.Protocol
 			}
 		}
 
+		public IEnumerable<object> ReadValues ()
+		{
+			for (int i = 0; i < message.Signature.Length; ++i) {
+				yield return ReadValue (message.Signature[i]);
+			}
+		}
+
 		public object ReadValue (Type type)
 		{
 			if (type == typeof (void))

--- a/src/TypeImplementer.cs
+++ b/src/TypeImplementer.cs
@@ -281,11 +281,15 @@ namespace DBus
 				if (!isGet)
 				{
 					ilg.Emit (OpCodes.Ldarg_1);
+					ilg.Emit (OpCodes.Box, source.GetParameters ()[0].ParameterType);
 				}
 
 				ilg.Emit (OpCodes.Tailcall);
 				ilg.Emit (target.IsFinal ? OpCodes.Call : OpCodes.Callvirt, target);
-				ilg.Emit (OpCodes.Castclass, source.ReturnType);
+
+				if (isGet)
+					ilg.Emit (source.ReturnType.IsValueType ? OpCodes.Unbox_Any : OpCodes.Castclass, source.ReturnType);
+
 				ilg.Emit (OpCodes.Ret);
 
 				if (isGet)

--- a/tests/ExportInterfaceTest.cs
+++ b/tests/ExportInterfaceTest.cs
@@ -24,18 +24,18 @@ namespace DBus.Tests
 		ObjectPath path = new ObjectPath ("/org/dbussharp/test");
 		
 		int event_a_count = 0;
-        
+
 		[TestFixtureSetUp]
-        public void Setup ()
-        {
+		public void Setup ()
+		{
 			test_server = new Test ();
 			Bus.Session.Register (path, test_server);
 			Assert.AreEqual (Bus.Session.RequestName (bus_name), RequestNameReply.PrimaryOwner);
 			
 			Assert.AreNotEqual (Bus.Session.RequestName (bus_name), RequestNameReply.PrimaryOwner);
 			test = Bus.Session.GetObject<ITestOne> (bus_name, path);
-        }
-		
+		}
+
 		/// <summary>
 		/// 
 		/// </summary>


### PR DESCRIPTION
Properties were previously involved in some name mangling to separate
them from normal methods, events were dealt with in a similar way. As
result, although signals worked correctly, properties did not.

This patch flips the implementation process on its head, first building
a set of methods for evaluation and removing pairs as properties or
signals (events) are implemented before passing the remainder to the
general function.

Property Get/Set is handled by two additional functions in the BusObject
class, the IL is generated specifically for them. Event listener
addition and removal IL generation is refactored into its own function
in the same way.
