### PR TITLE
Mapper: Correct Unknown Method Error Handling

### DIFF
--- a/src/Mapper.cs
+++ b/src/Mapper.cs
@@ -210,22 +210,7 @@ namespace DBus
 			                               method_call.Signature.Value,
 			                               method_call.Interface);
 
-			var error = new MessageContainer {
-				ErrorName = "org.freedesktop.DBus.Error.UnknownMethod",
-				Serial = msg.Header.Serial,
-				Signature = Signature.StringSig,
-			};
-
-			MessageWriter writer = new MessageWriter (Connection.NativeEndianness);
-			writer.Write (errMsg);
-			msg = error.Message;
-			msg.AttachBodyTo (writer);
-
-			//TODO: we should be more strict here, but this fallback was added as a quick fix for p2p
-			if (method_call.Sender != null)
-				msg.Header[FieldCode.Destination] = method_call.Sender;
-
-			return msg;
+			return method_call.CreateError ("org.freedesktop.DBus.Error.UnknownMethod", errMsg);
 		}
 
 		public static void WriteDynamicValues (MessageWriter mw, ParameterInfo[] parms, object[] vals)

--- a/src/Protocol/MessageContainer.cs
+++ b/src/Protocol/MessageContainer.cs
@@ -38,6 +38,7 @@ namespace DBus.Protocol
 				ErrorName = errorName,
 				ReplySerial = message.Header.Serial,
 				Signature = Signature.StringSig,
+				Destination = Sender
 			};
 
 			MessageWriter writer = new MessageWriter (message.Header.Endianness);


### PR DESCRIPTION
Since refactoring in commit, 3c278975c59cf8dbcfdfdf1184e4cf9c89de7ce3
we have experienced some issues when using e.g. d-feet with banshee, as
described in BGO#725446.

This patch corrects a small mistake in the refactoring process, in the
creation of an org.freedesktop.DBus.Error.UnknownMethod message.
