### PR TITLE
TypeImplementer: Implement multiple interfaces

### DIFF
--- a/src/TypeImplementer.cs
+++ b/src/TypeImplementer.cs
@@ -67,12 +67,11 @@ namespace DBus
 
 			TypeBuilder typeB = modB.DefineType (proxyName, TypeAttributes.Class | TypeAttributes.Public, parentType);
 
-			string interfaceName = null;
 			if (declType.IsInterface)
-				Implement (typeB, declType, interfaceName = Mapper.GetInterfaceName (declType));
+				Implement (typeB, declType, Mapper.GetInterfaceName (declType));
 
 			foreach (Type iface in declType.GetInterfaces ())
-				Implement (typeB, iface, interfaceName == null ? Mapper.GetInterfaceName (iface) : interfaceName);
+				Implement (typeB, iface, Mapper.GetInterfaceName (iface));
 
 			retT = typeB.CreateType ();
 


### PR DESCRIPTION
Issue #34 reports that only the main interface is presented, so that if
e.g. a programmer wishes to add the properties interface to a type, then
the resulting implementation attempts to call the method on the
incorrect interface.

This is due to a premature optimisation, which this patch removes.
