### PR TITLE
[build] Use mcs instead of gmcs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,11 +23,11 @@ AC_SUBST(PKG_CONFIG)
 MONO_REQ_VERSION=1.1.13
 PKG_CHECK_MODULES(MONO, mono >= $MONO_REQ_VERSION)
 
-AC_PATH_PROG(GMCS, gmcs, no)
-if test "x$GMCS" = "xno"; then
-	AC_MSG_ERROR([You need to install gmcs])
+AC_PATH_PROG(MCS, mcs, no)
+if test "x$MCS" = "xno"; then
+	AC_MSG_ERROR([You need to install mcs])
 fi
-AC_SUBST(GMCS)
+AC_SUBST(MCS)
 
 AC_PATH_PROG(GACUTIL, gacutil, no)
 if test "x$GACUTIL" = "xno"; then

--- a/src/daemon.mk
+++ b/src/daemon.mk
@@ -1,4 +1,4 @@
-CSC=gmcs
+CSC=mcs
 
 SRCS=Daemon.cs Server.cs ServerBus.cs
 

--- a/tools/tools.mk
+++ b/tools/tools.mk
@@ -1,6 +1,6 @@
 all: dbus-monitor.exe
 
-CSC=gmcs
+CSC=mcs
 CSFLAGS=-debug
 
 dbus-monitor.exe: Monitor.cs


### PR DESCRIPTION
as gmcs is not available in latest Mono

NB. I'm not sure if we need to do more than change "gmcs" usages to "mcs" ? it compiles OK but I wonder if there are profile versioning issues we need to be aware of?
