### PR TITLE
fixes reading nested IDictionary responses. Compile w/mcs hack

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -23,7 +23,7 @@ AC_SUBST(PKG_CONFIG)
 MONO_REQ_VERSION=1.1.13
 PKG_CHECK_MODULES(MONO, mono >= $MONO_REQ_VERSION)
 
-AC_PATH_PROG(GMCS, gmcs, no)
+AC_PATH_PROG(GMCS, mcs, no)
 if test "x$GMCS" = "xno"; then
 	AC_MSG_ERROR([You need to install gmcs])
 fi

--- a/src/Protocol/MessageReader.cs
+++ b/src/Protocol/MessageReader.cs
@@ -96,7 +96,8 @@ namespace DBus.Protocol
 			} else if (type == typeof (string)) {
 				readValueCache[type] = () => ReadString ();
 				return ReadString ();
-			} else if (type.IsGenericType && type.GetGenericTypeDefinition () == typeof (Dictionary<,>)) {
+			} else if (type.IsGenericType && type.GetGenericArguments().Length == 2 &&
+					type.IsAssignableFrom (typeof (Dictionary<,>).MakeGenericType(type.GetGenericArguments()))) {
 				Type[] genArgs = type.GetGenericArguments ();
 				readValueCache[type] = () => ReadDictionary (genArgs[0], genArgs[1]);
 				return ReadDictionary (genArgs[0], genArgs[1]);


### PR DESCRIPTION
Hopefully fixes the type checking for methods with return type IDictionary<IDictionary<,>> which I think caused issue #25 as I described in this post:
http://stackoverflow.com/questions/33326300/accessing-networkmanager-connection-settings-through-dbus-sharp/33335133#33335133
