### PR TITLE
Fix reading structs of primitives

### DIFF
--- a/src/Protocol/MessageReader.cs
+++ b/src/Protocol/MessageReader.cs
@@ -505,7 +505,7 @@ namespace DBus.Protocol
 						ptr[2 * i - pos + (sof - 1) - j] = data[j];
 			}
 
-			pos += (int)length * sof;
+			pos += (int)length;
 		}
 
 		bool[] MarshalBoolArray (uint length)


### PR DESCRIPTION
The length argument for DirectCopy() is in bytes, not in number of elements,
therefore DirectCopy() must not multiply length with the field size.
