### PR TITLE
 Fix alignment of Dictionary<> objects

### DIFF
--- a/src/Protocol/MessageReader.cs
+++ b/src/Protocol/MessageReader.cs
@@ -505,7 +505,7 @@ namespace DBus.Protocol
 						ptr[2 * i - pos + (sof - 1) - j] = data[j];
 			}
 
-			pos += (int)length * sof;
+			pos += (int)length;
 		}
 
 		bool[] MarshalBoolArray (uint length)

--- a/src/Protocol/Signature.cs
+++ b/src/Protocol/Signature.cs
@@ -636,6 +636,9 @@ namespace DBus.Protocol
 			if (type.IsArray)
 				return DType.Array;
 
+			if (type.IsGenericType && (type.GetGenericTypeDefinition () == typeof (IDictionary<,>) || type.GetGenericTypeDefinition () == typeof (Dictionary<,>)))
+				return DType.Array;
+
 			//if (type.UnderlyingSystemType != null)
 			//	return TypeToDType (type.UnderlyingSystemType);
 			if (Mapper.IsPublic (type))


### PR DESCRIPTION
Signature.TypeToDType() did not handle Dictionary<> types, which meant that
they were treated as structures (DType.StructBegin). However, Dictionary<>
instances must be treated as arrays (DType.Array), so that the proper
alignment is used in MessageReader.ReadArray<>() (4 instead of 8).

This also includes the commit from #52.
