### PR TITLE
Fixing Array Writing

### DIFF
--- a/src/Protocol/MessageWriter.cs
+++ b/src/Protocol/MessageWriter.cs
@@ -341,6 +341,8 @@ namespace DBus.Protocol
 
 			Type type = val.GetType ();
 			
+			//TODO: Take a look at TypeImplementer
+			// and understand why does this happens
 			if (type.IsArray) {
 				Write(type, val);
 			}

--- a/src/Protocol/MessageWriter.cs
+++ b/src/Protocol/MessageWriter.cs
@@ -340,8 +340,13 @@ namespace DBus.Protocol
 			}
 
 			Type type = val.GetType ();
-
-			WriteVariant (type, val);
+			
+			if (type.IsArray) {
+				Write(type, val);
+			}
+			else{
+				WriteVariant (type, val);
+			}
 		}
 
 		public void WriteVariant (Type type, object val)

--- a/src/Protocol/MessageWriter.cs
+++ b/src/Protocol/MessageWriter.cs
@@ -341,14 +341,12 @@ namespace DBus.Protocol
 
 			Type type = val.GetType ();
 			
-			//TODO: Take a look at TypeImplementer
-			// and understand why does this happens
-			if (type.IsArray) {
-				Write(type, val);
-			}
-			else{
+			// TODO: workaround issue with array being written as variant
+			// See PR for context: https://github.com/mono/dbus-sharp/pull/58
+			if (type.IsArray)
+				Write (type, val);
+			else
 				WriteVariant (type, val);
-			}
 		}
 
 		public void WriteVariant (Type type, object val)


### PR DESCRIPTION
I found a bug at MessageWriter, when Marshalling Arrays of Arrays. According to [D-Bus Specification](https://dbus.freedesktop.org/doc/dbus-specification.html), an **Array** is a **Container** and should not be Marshalled as a Variant (as MessageWritter is doing now).

Byte Arrays of Arrays are being passed inside a object, which makes MessageWriter to treat them as defaulf objects, which made them being wrote as Signature + Array, which made D-Bus daemon not accept it.

I believe this is a side effect of other big problem (maybe with TypeImplementer itself), but I hadn't the proper time to debug it.

This is just a quick-fix to the problem, since I'm treating the symptom rather than the problem itself. 