### PR TITLE
Revert "Fixing Array Writing"

### DIFF
--- a/src/Protocol/MessageWriter.cs
+++ b/src/Protocol/MessageWriter.cs
@@ -356,13 +356,8 @@ namespace DBus.Protocol
 			}
 
 			Type type = val.GetType ();
-			
-			// TODO: workaround issue with array being written as variant
-			// See PR for context: https://github.com/mono/dbus-sharp/pull/58
-			if (type.IsArray)
-				Write (type, val);
-			else
-				WriteVariant (type, val);
+
+			WriteVariant (type, val);
 		}
 
 		public void WriteVariant (Type type, object val)


### PR DESCRIPTION
I think this change is broken:

When `MessageWriter.Write(object)` is called, a variant should be written (see also the comment above the method). If the object is an array, a variant containing the array should be written. A array which is not in a variant can be written using `MessageWriter.Write(Type,object)` or `MessageWriter.WriteArray(T)`.

If the code somewhere calls `MessageWriter.Write(object)` when a plain array is needed, the caller should be fixed.

Currently, this change breaks returning an array as a variant, e.g. for the following service:

```
using System;
using DBus;
[Interface ("test.test")]
public interface TestInterface {
  object GetVal ();
}
public class Test : TestInterface {
  public object GetVal () { return new int[3] { 1, 2, 3 }; }
  public static void Main () {
    Bus bus = Bus.Session;
    bus.RequestName ("test.test");
    bus.Register (new ObjectPath ("/test/test"), new Test ());
    while (true)
      bus.Iterate ();
  }
}
```
Calling `GetVal` will disconnect the service:
```
qdbus --literal test.test /test/test test.test.GetVal
Error: org.freedesktop.DBus.Error.NoReply
```
