### PR TITLE
Fix race conditions is case of threaded Iterate() call

### DIFF
--- a/src/Bus.cs
+++ b/src/Bus.cs
@@ -59,11 +59,13 @@ namespace DBus
 				throw new ArgumentNullException ("address");
 
 			Bus bus;
-			if (buses.TryGetValue (address, out bus))
-				return bus;
+			lock (buses) {
+				if (buses.TryGetValue (address, out bus))
+					return bus;
 
-			bus = new Bus (address);
-			buses[address] = bus;
+				bus = new Bus (address);
+				buses[address] = bus;
+			}
 
 			return bus;
 		}

--- a/src/BusException.cs
+++ b/src/BusException.cs
@@ -25,7 +25,7 @@ namespace DBus
 		{
 			get
 			{
-				return ErrorName + ": " + ErrorMessage;
+				return ErrorName + ": " + ErrorMessage + Environment.NewLine + this.StackTrace;
 			}
 		}
 

--- a/src/ExportObject.cs
+++ b/src/ExportObject.cs
@@ -67,9 +67,11 @@ namespace DBus
 		internal static MethodCaller GetMCaller (MethodInfo mi)
 		{
 			MethodCaller mCaller;
-			if (!mCallers.TryGetValue (mi, out mCaller)) {
-				mCaller = TypeImplementer.GenCaller (mi);
-				mCallers[mi] = mCaller;
+			lock (mCallers) {
+				if (!mCallers.TryGetValue (mi, out mCaller)) {
+					mCaller = TypeImplementer.GenCaller (mi);
+					mCallers[mi] = mCaller;
+				}
 			}
 			return mCaller;
 		}
@@ -90,11 +92,7 @@ namespace DBus
 				return;
 			}
 
-			MethodCaller mCaller;
-			if (!mCallers.TryGetValue (mi, out mCaller)) {
-				mCaller = TypeImplementer.GenCaller (mi);
-				mCallers[mi] = mCaller;
-			}
+			MethodCaller mCaller = GetMCaller (mi);
 
 			Signature inSig, outSig;
 			bool hasDisposableList;

--- a/src/Protocol/PendingCall.cs
+++ b/src/Protocol/PendingCall.cs
@@ -7,21 +7,31 @@ using System.Threading;
 
 namespace DBus.Protocol
 {
-	public class PendingCall : IAsyncResult
+	public class PendingCall : IAsyncResult, IDisposable
 	{
-		Connection conn;
-		Message reply;
-		ManualResetEvent waitHandle;
-		bool completedSync;
-		bool keepFDs;
-		
+		private Connection conn;
+		private Message reply;
+		private ManualResetEvent waitHandle = new ManualResetEvent (false);
+		private bool completedSync = false;
+		private bool keepFDs;
+		private CancellationTokenSource stopWait = new CancellationTokenSource();
+
 		public event Action<Message> Completed;
 
-		public PendingCall (Connection conn) : this (conn, false) {}
+		public PendingCall(Connection conn)
+			: this (conn, false)
+		{
+		}
+
 		public PendingCall (Connection conn, bool keepFDs)
 		{
 			this.conn = conn;
 			this.keepFDs = keepFDs;
+		}
+
+		public void Dispose()
+		{
+			stopWait.Dispose ();
 		}
 
 		internal bool KeepFDs
@@ -33,36 +43,24 @@ namespace DBus.Protocol
 
 		public Message Reply {
 			get {
-				if (reply != null)
-					return reply;
-
-				if (Thread.CurrentThread == conn.mainThread) {
-					while (reply == null)
-						conn.HandleMessage (conn.Transport.ReadMessage ());
-
-					completedSync = true;
-
-					conn.DispatchSignals ();
-				} else {
-					if (waitHandle == null)
-						Interlocked.CompareExchange (ref waitHandle, new ManualResetEvent (false), null);
-
-					while (reply == null)
-						waitHandle.WaitOne ();
-
-					completedSync = false;
+				while (reply == null) {
+					try {
+						conn.Iterate (stopWait.Token);
+					}
+					catch (OperationCanceledException) {
+					}
 				}
-
 				return reply;
-			} 
+			}
+
 			set {
 				if (reply != null)
 					throw new Exception ("Cannot handle reply more than once");
-
 				reply = value;
 
-				if (waitHandle != null)
-					waitHandle.Set ();
+				waitHandle.Set ();
+				
+				stopWait.Cancel ();
 
 				if (Completed != null)
 					Completed (reply);
@@ -84,9 +82,6 @@ namespace DBus.Protocol
 
 		WaitHandle IAsyncResult.AsyncWaitHandle {
 			get {
-				if (waitHandle == null)
-					waitHandle = new ManualResetEvent (false);
-
 				return waitHandle;
 			}
 		}


### PR DESCRIPTION
For example, in [mono/uia2atk](https://github.com/mono/uia2atk) project one use two threads:
* the main thread is used to send outgoing DBus-messages;
* a dedicated thread spawned to call `Bus.Session.Iterate()` into an infinite loop to serve incoming DBus-messages.

This leads to numerous multithreading issues. Current PR is aimed to fix them.